### PR TITLE
Misc details

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,3 +8,5 @@ index.html: $(top_srcdir)/README.md
 	$(AM_V_GEN)$(MARKDOWN) $(top_srcdir)/README.md > $@
 CLEANFILES = index.html
 endif
+
+DISTCHECK_CONFIGURE_FLAGS = --with-geany-libdir='$${libdir}/geany'

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = data screenshots overview
-doc_DATA = COPYING README.md
-EXTRA_DIST = README.md
+dist_doc_DATA = COPYING README.md
 
 if WITH_MARKDOWN
-doc_DATA += index.html
+doc_DATA = index.html
 index.html: $(top_srcdir)/README.md
 	$(AM_V_GEN)$(MARKDOWN) $(top_srcdir)/README.md > $@
 CLEANFILES = index.html

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall foreign])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
 LT_INIT([disable-static])

--- a/configure.ac
+++ b/configure.ac
@@ -11,9 +11,13 @@ LT_INIT([disable-static])
 AC_PROG_CC_C99
 
 PKG_CHECK_MODULES([GEANY], [geany])
-geany_libdir=`$PKG_CONFIG --variable=libdir geany`
-geany_plugindir="$geany_libdir/geany"
-AC_SUBST([GEANY_PLUGINDIR], [$geany_plugindir])
+AC_ARG_WITH([geany-libdir],
+            [AS_HELP_STRING([--with-geany-libdir=DIR],
+                            [Install the plugin library in DIR])],
+            [],
+            [geany_libdir=`$PKG_CONFIG --variable=libdir geany`
+             with_geany_libdir="$geany_libdir/geany"])
+AC_SUBST([GEANY_PLUGINDIR], [$with_geany_libdir])
 
 AC_PATH_PROG([MARKDOWN], [markdown])
 AM_CONDITIONAL([WITH_MARKDOWN], [test "x$MARKDOWN" != "x"])

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([-Wall foreign])
+AM_INIT_AUTOMAKE([1.11.2 -Wall foreign])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
 LT_INIT([disable-static])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,1 +1,1 @@
-pkgdata_DATA = $(top_srcdir)/data/prefs.ui
+dist_pkgdata_DATA = prefs.ui

--- a/overview/Makefile.am
+++ b/overview/Makefile.am
@@ -18,4 +18,5 @@ overview_la_SOURCES = \
 	overviewscintilla.c \
 	overviewscintilla.h
 
-overview_la_LDFLAGS = -module -avoid-version $(GEANY_LIBS)
+overview_la_LDFLAGS = -module -avoid-version
+overview_la_LIBADD = $(GEANY_LIBS)

--- a/overview/overviewcolor.c
+++ b/overview/overviewcolor.c
@@ -127,7 +127,7 @@ overview_color_from_rgba (OverviewColor *color,
   color->red   = rgba->red;
   color->green = rgba->green;
   color->blue  = rgba->blue;
-  color->alpha = rgba->value;
+  color->alpha = rgba->alpha;
 }
 
 void

--- a/overview/overviewcolor.h
+++ b/overview/overviewcolor.h
@@ -37,7 +37,7 @@ typedef struct
 }
 OverviewColor;
 
-GType          overview_color_get_type       (void);
+GType          overview_color_get_type       (void) G_GNUC_CONST;
 OverviewColor *overview_color_copy           (OverviewColor       *color);
 void           overview_color_free           (OverviewColor       *color);
 gboolean       overview_color_equal          (const OverviewColor *color1,

--- a/overview/overviewprefs.h
+++ b/overview/overviewprefs.h
@@ -37,7 +37,7 @@ G_BEGIN_DECLS
 typedef struct OverviewPrefs_      OverviewPrefs;
 typedef struct OverviewPrefsClass_ OverviewPrefsClass;
 
-GType          overview_prefs_get_type       (void);
+GType          overview_prefs_get_type       (void) G_GNUC_CONST;
 OverviewPrefs *overview_prefs_new            (void);
 gboolean       overview_prefs_load           (OverviewPrefs *prefs,
                                               const gchar   *filename,

--- a/overview/overviewprefspanel.h
+++ b/overview/overviewprefspanel.h
@@ -38,7 +38,7 @@ G_BEGIN_DECLS
 typedef struct OverviewPrefsPanel_      OverviewPrefsPanel;
 typedef struct OverviewPrefsPanelClass_ OverviewPrefsPanelClass;
 
-GType      overview_prefs_panel_get_type (void);
+GType      overview_prefs_panel_get_type (void) G_GNUC_CONST;
 GtkWidget *overview_prefs_panel_new      (OverviewPrefs *prefs,
                                           GtkDialog     *host_dialog);
 

--- a/overview/overviewscintilla.h
+++ b/overview/overviewscintilla.h
@@ -38,7 +38,7 @@ G_BEGIN_DECLS
 typedef struct OverviewScintilla_        OverviewScintilla;
 typedef struct OverviewScintillaClass_   OverviewScintillaClass;
 
-GType         overview_scintilla_get_type                  (void);
+GType         overview_scintilla_get_type                  (void) G_GNUC_CONST;
 GtkWidget    *overview_scintilla_new                       (ScintillaObject     *src_sci);
 void          overview_scintilla_queue_draw                (OverviewScintilla   *sci);
 GdkCursorType overview_scintilla_get_cursor                (OverviewScintilla   *sci);

--- a/screenshots/Makefile.am
+++ b/screenshots/Makefile.am
@@ -1,7 +1,7 @@
 screenshotdir = $(docdir)/screenshots
-screenshot_DATA = \
-	$(top_srcdir)/screenshots/screenshot-dark.png \
-	$(top_srcdir)/screenshots/screenshot-keybindings.png \
-	$(top_srcdir)/screenshots/screenshot-light.png \
-	$(top_srcdir)/screenshots/screenshot-prefs.png \
-	$(top_srcdir)/screenshots/screenshot-view-menu.png
+dist_screenshot_DATA = \
+	screenshot-dark.png \
+	screenshot-keybindings.png \
+	screenshot-light.png \
+	screenshot-prefs.png \
+	screenshot-view-menu.png


### PR DESCRIPTION
- Fix compilation on GTK3 (still doesn't work)
- Mark `get_type()` functions as `G_GNUC_CONST` Because We Can™

Warning: based on top of #3, so it's probably better to merge it first and then consider this :)
